### PR TITLE
Implement regsub command parsing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/elkrammer/irule-validator
 
-go 1.23
+go 1.24
 
-require github.com/spf13/pflag v1.0.5 // indirect
+require github.com/spf13/pflag v1.0.6

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
-github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
+github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=

--- a/parser/keywords.go
+++ b/parser/keywords.go
@@ -27,7 +27,7 @@ var (
 		"sha256", "sha384", "sha512", "redirect", "compress", "decompress", "cookie",
 		"getfield", "findstr", "scan", "matchclass", "priority", "when", "use",
 		"client_addr", "server_addr", "ip2rd", "rd2ip", "replace", "matches_regex",
-		"exists", "whereis", "drop",
+		"exists", "whereis", "drop", "regsub",
 	}
 	validStringOperations = map[string]bool{
 		"contains":  true,
@@ -47,5 +47,9 @@ var (
 		"range":     true,
 		"index":     true,
 		"last":      true,
+	}
+	validRegsubFlags = map[string]bool{
+		"all":    true,
+		"nocase": true,
 	}
 )

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -931,3 +931,47 @@ func TestSwitchStatementWithComments(t *testing.T) {
 		t.Error("Expected error for comment in switch statement")
 	}
 }
+
+func TestRegsubVariations(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "RegsubNoFlagsSimpleStrings",
+			input: `if {[regsub "pattern" "input string" "replace" varName] == 1} {}`,
+		},
+		{
+			name:  "RegsubAllFlagBracedPattern",
+			input: `if {[regsub -all {/path/+} [HTTP::uri] /newpath var] > 0} {}`,
+		},
+		{
+			name:  "RegsubNocaseSlashUriCompareZero",
+			input: `if {[regsub -nocase /test [HTTP::uri] /test new_uri] == 0 } {}`,
+		},
+		{
+		name:  "RegsubNocaseFlagMixedArgs",
+		input: `if {[regsub -nocase $varPattern "Some Input" {Replacement} otherVar] != 0} {}`,
+		 },
+		{
+			name:  "RegsubExplicitEndOfFlags",
+			input: `if {[regsub -nocase -- /pattern/ [HTTP::uri] /replace/ var] == 1} {}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l := lexer.New(tt.input)
+			p := New(l)
+			_ = p.ParseProgram()
+
+			errors := p.Errors()
+			if len(errors) != 0 {
+				t.Errorf("Parser encountered %d errors parsing input:\n%s", len(errors), tt.input)
+				for i, msg := range errors {
+					t.Errorf("  Error %d: %s", i+1, msg)
+				}
+			}
+		})
+	}
+}

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -37,8 +37,8 @@ func Start(in io.Reader, out io.Writer) {
 
 func printParserErrors(out io.Writer, errors []string) {
 	io.WriteString(out, "Woops! We ran into some funky business here!\n")
-	io.WriteString(out, " parser errors:\n")
+	io.WriteString(out, "Parser Errors:\n")
 	for _, msg := range errors {
-		io.WriteString(out, "\t"+msg+"\n")
+		io.WriteString(out, "  "+msg+"\n")
 	}
 }

--- a/test-data/comparison.irule
+++ b/test-data/comparison.irule
@@ -1,0 +1,3 @@
+if { [string length [HTTP::uri]] > 0 } {
+  log local0. "URI is not empty"
+}

--- a/test-data/regsub.irule
+++ b/test-data/regsub.irule
@@ -1,0 +1,11 @@
+when HTTP_REQUEST {
+  switch -glob -- [string tolower [HTTP::uri]] {
+    "/testv2*" {
+      if {[regsub -nocase /test [HTTP::uri] /test new_uri] > 0 } {
+        HTTP::uri $new_uri
+      }
+      HTTP::host "test.com"
+      pool web
+    }
+  }
+}

--- a/test-data/regsub2.irule
+++ b/test-data/regsub2.irule
@@ -1,0 +1,11 @@
+when HTTP_REQUEST {
+    set inputString "input string"
+    set pattern "input"
+    set replacement "output"
+
+    set result [regsub $pattern $inputString $replacement newString]
+
+    if {$result > 0} {
+        log local0. "Modified String: $newString"
+    }
+}

--- a/test-data/regsub3.irule
+++ b/test-data/regsub3.irule
@@ -1,0 +1,1 @@
+if {[regsub -all "\.php$" [HTTP::path] ".html" new_path] > 0} {}

--- a/token/token.go
+++ b/token/token.go
@@ -62,6 +62,7 @@ const (
 	FOREACH = "FOREACH"
 	IN      = "IN"
 	REGEX   = "REGEX"
+	REGSUB  = "REGSUB"
 
 	// HTTP TOKENS
 	HTTP_REQUEST  = "HTTP_REQUEST"
@@ -218,6 +219,7 @@ var keywords = map[string]TokenType{
 	"in":          IN,
 	"ltm":         LTM,
 	"rule":        RULE,
+	"regsub":      REGSUB,
 
 	// F5 Event Contexts
 	"HTTP_REQUEST":        HTTP_REQUEST,


### PR DESCRIPTION
Adds support for parsing the Tcl `regsub` command within iRules.

Handles various argument types including flags (`-all`, `-nocase`, `--`), variable substitution, command substitution, braced literals (`{...}`), quoted strings, and unquoted words (including those starting with `/`).